### PR TITLE
Fix index-out-of-range on empty string

### DIFF
--- a/murmur32.go
+++ b/murmur32.go
@@ -107,7 +107,10 @@ func Sum32(data []byte) uint32 {
 	var h1 uint32 = 1
 
 	nblocks := len(data) / 4
-	p := uintptr(unsafe.Pointer(&data[0]))
+	var p uintptr
+	if len(data) > 0 {
+		p = uintptr(unsafe.Pointer(&data[0]))
+	}
 	p1 := p + uintptr(4*nblocks)
 	for ; p < p1; p += 4 {
 		k1 := *(*uint32)(unsafe.Pointer(p))


### PR DESCRIPTION
Access to data[0] is not valid if len(data) == 0

This fails for me on go1.1beta . (Didn't test on go1.0)
