### PR TITLE
Add seeded versions of 32-bit hashing functions (NewSeeded32() and SeededSum32…

### DIFF
--- a/murmur32.go
+++ b/murmur32.go
@@ -25,9 +25,14 @@ type digest32 struct {
 }
 
 func New32() hash.Hash32 {
+	return NewSeeded32(0)
+}
+
+func NewSeeded32(seed uint32) hash.Hash32 {
 	d := new(digest32)
 	d.bmixer = d
 	d.Reset()
+	d.h1 = seed
 	return d
 }
 
@@ -103,8 +108,13 @@ func rotl32(x uint32, r byte) uint32 {
 //     hasher.Write(data)
 //     return hasher.Sum32()
 func Sum32(data []byte) uint32 {
+	return SumSeed32(0, data)
+}
 
-	var h1 uint32 = 0
+// SeededSum32 returns the MurmurHash3 sum of data, seeded with the provided
+// value. A seed of 0 is equvalent to using Sum32().
+func SeededSum32(seed uint32, data []byte) uint32 {
+	h1 := seed
 
 	nblocks := len(data) / 4
 	var p uintptr

--- a/murmur32.go
+++ b/murmur32.go
@@ -108,7 +108,7 @@ func rotl32(x uint32, r byte) uint32 {
 //     hasher.Write(data)
 //     return hasher.Sum32()
 func Sum32(data []byte) uint32 {
-	return SumSeed32(0, data)
+	return SeededSum32(0, data)
 }
 
 // SeededSum32 returns the MurmurHash3 sum of data, seeded with the provided


### PR DESCRIPTION
…()). These work the same way as the regular functions, but can be started with h1 != 0.

I'm implementing Bitcoin BIP-0037 (https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki) in Go and would like to use this library to create hashes for the bloom filter. Test data comes from: https://bitcoin.org/en/developer-examples#creating-a-bloom-filter