### PR TITLE
add seed to constructor of all hash (New32, New64, New128)

### DIFF
--- a/murmur128.go
+++ b/murmur128.go
@@ -31,10 +31,11 @@ type digest128 struct {
 	h2 uint64 // Unfinalized running hash part 2.
 }
 
-func New128() Hash128 {
+func New128(seed1 uint64, seed2 uint64) Hash128 {
 	d := new(digest128)
 	d.bmixer = d
-	d.Reset()
+	d.h1 = seed1
+	d.h2 = seed2
 	return d
 }
 

--- a/murmur32.go
+++ b/murmur32.go
@@ -24,10 +24,11 @@ type digest32 struct {
 	h1 uint32 // Unfinalized running hash.
 }
 
-func New32() hash.Hash32 {
+func New32(seed uint32) hash.Hash32 {
 	d := new(digest32)
 	d.bmixer = d
 	d.Reset()
+	d.h1 = seed
 	return d
 }
 

--- a/murmur64.go
+++ b/murmur64.go
@@ -14,8 +14,8 @@ var (
 // digest64 is half a digest128.
 type digest64 digest128
 
-func New64() hash.Hash64 {
-	d := (*digest64)(New128().(*digest128))
+func New64(seed uint64) hash.Hash64 {
+	d := (*digest64)(New128(seed, 0).(*digest128))
 	return d
 }
 

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -22,13 +22,13 @@ var data = []struct {
 func TestRef(t *testing.T) {
 	for _, elem := range data {
 
-		var h32 hash.Hash32 = New32()
+		var h32 hash.Hash32 = New32(0)
 		h32.Write([]byte(elem.s))
 		if v := h32.Sum32(); v != elem.h32 {
 			t.Errorf("'%s': 0x%x (want 0x%x)", elem.s, v, elem.h32)
 		}
 
-		var h32_byte hash.Hash32 = New32()
+		var h32_byte hash.Hash32 = New32(0)
 		h32_byte.Write([]byte(elem.s))
 		target := fmt.Sprintf("%08x", elem.h32)
 		if p := fmt.Sprintf("%x", h32_byte.Sum(nil)); p != target {
@@ -39,13 +39,13 @@ func TestRef(t *testing.T) {
 			t.Errorf("'%s': 0x%x (want 0x%x)", elem.s, v, elem.h32)
 		}
 
-		var h64 hash.Hash64 = New64()
+		var h64 hash.Hash64 = New64(0)
 		h64.Write([]byte(elem.s))
 		if v := h64.Sum64(); v != elem.h64_1 {
 			t.Errorf("'%s': 0x%x (want 0x%x)", elem.s, v, elem.h64_1)
 		}
 
-		var h64_byte hash.Hash64 = New64()
+		var h64_byte hash.Hash64 = New64(0)
 		h64_byte.Write([]byte(elem.s))
 		target = fmt.Sprintf("%016x", elem.h64_1)
 		if p := fmt.Sprintf("%x", h64_byte.Sum(nil)); p != target {
@@ -56,13 +56,13 @@ func TestRef(t *testing.T) {
 			t.Errorf("'%s': 0x%x (want 0x%x)", elem.s, v, elem.h64_1)
 		}
 
-		var h128 Hash128 = New128()
+		var h128 Hash128 = New128(0, 0)
 		h128.Write([]byte(elem.s))
 		if v1, v2 := h128.Sum128(); v1 != elem.h64_1 || v2 != elem.h64_2 {
 			t.Errorf("'%s': 0x%x-0x%x (want 0x%x-0x%x)", elem.s, v1, v2, elem.h64_1, elem.h64_2)
 		}
 
-		var h128_byte Hash128 = New128()
+		var h128_byte Hash128 = New128(0, 0)
 		h128_byte.Write([]byte(elem.s))
 		target = fmt.Sprintf("%016x%016x", elem.h64_1, elem.h64_2)
 		if p := fmt.Sprintf("%x", h128_byte.Sum(nil)); p != target {
@@ -77,8 +77,8 @@ func TestRef(t *testing.T) {
 
 func TestIncremental(t *testing.T) {
 	for _, elem := range data {
-		h32 := New32()
-		h128 := New128()
+		h32 := New32(0)
+		h128 := New128(0, 0)
 		for i, j, k := 0, 0, len(elem.s); i < k; i = j {
 			j = 2*i + 3
 			if j > k {
@@ -166,7 +166,7 @@ func benchPartial32(b *testing.B, length int) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		hasher := New32()
+		hasher := New32(0)
 		hasher.Write(buf[0:start])
 
 		for j := start; j+k <= length; j += k {


### PR DESCRIPTION
Current implementation lack of capability to seed.
I've wonder between change the constructor interface (lacking backward compability) and new interface like `New32WithSeed`, but lacking of seed capability seems to be not fit with original implementation, so change the original constructor seems to be better.

@spaolacci please take a look.

Thank you in advance.
