### PR TITLE
Write benchmarks using sub-benchmarks

### DIFF
--- a/murmur_test.go
+++ b/murmur_test.go
@@ -115,9 +115,10 @@ func TestIncremental(t *testing.T) {
 }
 
 func Benchmark32(b *testing.B) {
-	for length := 1; length <= 8192; length *= 2 {
+	buf := make([]byte, 8192)
+	for length := 1; length <= cap(buf); length *= 2 {
 		b.Run(strconv.Itoa(length), func(b *testing.B) {
-			buf := make([]byte, length)
+			buf = buf[:length]
 			b.SetBytes(int64(length))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -128,9 +129,10 @@ func Benchmark32(b *testing.B) {
 }
 
 func BenchmarkPartial32(b *testing.B) {
-	for length := 8; length <= 128; length *= 2 {
+	buf := make([]byte, 128)
+	for length := 8; length <= cap(buf); length *= 2 {
 		b.Run(strconv.Itoa(length), func(b *testing.B) {
-			buf := make([]byte, length)
+			buf = buf[:length]
 			b.SetBytes(int64(length))
 
 			start := (32 / 8) / 2
@@ -155,9 +157,10 @@ func BenchmarkPartial32(b *testing.B) {
 }
 
 func Benchmark64(b *testing.B) {
-	for length := 1; length <= 8192; length *= 2 {
+	buf := make([]byte, 8192)
+	for length := 1; length <= cap(buf); length *= 2 {
 		b.Run(strconv.Itoa(length), func(b *testing.B) {
-			buf := make([]byte, length)
+			buf = buf[:length]
 			b.SetBytes(int64(length))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -168,9 +171,10 @@ func Benchmark64(b *testing.B) {
 }
 
 func Benchmark128(b *testing.B) {
-	for length := 1; length <= 8192; length *= 2 {
+	buf := make([]byte, 8192)
+	for length := 1; length <= cap(buf); length *= 2 {
 		b.Run(strconv.Itoa(length), func(b *testing.B) {
-			buf := make([]byte, length)
+			buf = buf[:length]
 			b.SetBytes(int64(length))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -2,6 +2,7 @@ package murmur3
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 )
 
@@ -113,153 +114,68 @@ func TestIncremental(t *testing.T) {
 	}
 }
 
-//---
-
-func bench32(b *testing.B, length int) {
-	buf := make([]byte, length)
-	b.SetBytes(int64(length))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		Sum32(buf)
+func Benchmark32(b *testing.B) {
+	for length := 1; length <= 8192; length *= 2 {
+		b.Run(strconv.Itoa(length), func(b *testing.B) {
+			buf := make([]byte, length)
+			b.SetBytes(int64(length))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				Sum32(buf)
+			}
+		})
 	}
 }
 
-func Benchmark32_1(b *testing.B) {
-	bench32(b, 1)
-}
-func Benchmark32_2(b *testing.B) {
-	bench32(b, 2)
-}
-func Benchmark32_4(b *testing.B) {
-	bench32(b, 4)
-}
-func Benchmark32_8(b *testing.B) {
-	bench32(b, 8)
-}
-func Benchmark32_16(b *testing.B) {
-	bench32(b, 16)
-}
-func Benchmark32_32(b *testing.B) {
-	bench32(b, 32)
-}
-func Benchmark32_64(b *testing.B) {
-	bench32(b, 64)
-}
-func Benchmark32_128(b *testing.B) {
-	bench32(b, 128)
-}
-func Benchmark32_256(b *testing.B) {
-	bench32(b, 256)
-}
-func Benchmark32_512(b *testing.B) {
-	bench32(b, 512)
-}
-func Benchmark32_1024(b *testing.B) {
-	bench32(b, 1024)
-}
-func Benchmark32_2048(b *testing.B) {
-	bench32(b, 2048)
-}
-func Benchmark32_4096(b *testing.B) {
-	bench32(b, 4096)
-}
-func Benchmark32_8192(b *testing.B) {
-	bench32(b, 8192)
-}
+func BenchmarkPartial32(b *testing.B) {
+	for length := 8; length <= 128; length *= 2 {
+		b.Run(strconv.Itoa(length), func(b *testing.B) {
+			buf := make([]byte, length)
+			b.SetBytes(int64(length))
 
-//---
+			start := (32 / 8) / 2
+			chunks := 7
+			k := length / chunks
+			tail := (length - start) % k
 
-func benchPartial32(b *testing.B, length int) {
-	buf := make([]byte, length)
-	b.SetBytes(int64(length))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				hasher := New32()
+				hasher.Write(buf[0:start])
 
-	start := (32 / 8) / 2
-	chunks := 7
-	k := length / chunks
-	tail := (length - start) % k
+				for j := start; j+k <= length; j += k {
+					hasher.Write(buf[j : j+k])
+				}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		hasher := New32()
-		hasher.Write(buf[0:start])
-
-		for j := start; j+k <= length; j += k {
-			hasher.Write(buf[j : j+k])
-		}
-
-		hasher.Write(buf[length-tail:])
-		hasher.Sum32()
+				hasher.Write(buf[length-tail:])
+				hasher.Sum32()
+			}
+		})
 	}
 }
 
-func BenchmarkPartial32_8(b *testing.B) {
-	benchPartial32(b, 8)
-}
-func BenchmarkPartial32_16(b *testing.B) {
-	benchPartial32(b, 16)
-}
-func BenchmarkPartial32_32(b *testing.B) {
-	benchPartial32(b, 32)
-}
-func BenchmarkPartial32_64(b *testing.B) {
-	benchPartial32(b, 64)
-}
-func BenchmarkPartial32_128(b *testing.B) {
-	benchPartial32(b, 128)
-}
-
-//---
-
-func bench128(b *testing.B, length int) {
-	buf := make([]byte, length)
-	b.SetBytes(int64(length))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		Sum128(buf)
+func Benchmark64(b *testing.B) {
+	for length := 1; length <= 8192; length *= 2 {
+		b.Run(strconv.Itoa(length), func(b *testing.B) {
+			buf := make([]byte, length)
+			b.SetBytes(int64(length))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				Sum64(buf)
+			}
+		})
 	}
 }
 
-func Benchmark128_1(b *testing.B) {
-	bench128(b, 1)
+func Benchmark128(b *testing.B) {
+	for length := 1; length <= 8192; length *= 2 {
+		b.Run(strconv.Itoa(length), func(b *testing.B) {
+			buf := make([]byte, length)
+			b.SetBytes(int64(length))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				Sum128(buf)
+			}
+		})
+	}
 }
-func Benchmark128_2(b *testing.B) {
-	bench128(b, 2)
-}
-func Benchmark128_4(b *testing.B) {
-	bench128(b, 4)
-}
-func Benchmark128_8(b *testing.B) {
-	bench128(b, 8)
-}
-func Benchmark128_16(b *testing.B) {
-	bench128(b, 16)
-}
-func Benchmark128_32(b *testing.B) {
-	bench128(b, 32)
-}
-func Benchmark128_64(b *testing.B) {
-	bench128(b, 64)
-}
-func Benchmark128_128(b *testing.B) {
-	bench128(b, 128)
-}
-func Benchmark128_256(b *testing.B) {
-	bench128(b, 256)
-}
-func Benchmark128_512(b *testing.B) {
-	bench128(b, 512)
-}
-func Benchmark128_1024(b *testing.B) {
-	bench128(b, 1024)
-}
-func Benchmark128_2048(b *testing.B) {
-	bench128(b, 2048)
-}
-func Benchmark128_4096(b *testing.B) {
-	bench128(b, 4096)
-}
-func Benchmark128_8192(b *testing.B) {
-	bench128(b, 8192)
-}
-
-//---


### PR DESCRIPTION
While I'm at it, also add benchmarks for Sum64.

This changes the output lines from this:

```
Benchmark32_1-4                 200000000                9.00 ns/op      111.15 MB/s
Benchmark32_2-4                 200000000                9.69 ns/op      206.48 MB/s
Benchmark32_4-4                 100000000               10.2 ns/op       394.04 MB/s
Benchmark32_8-4                 100000000               12.0 ns/op       668.48 MB/s
```

to this:

```
Benchmark32/1-4         200000000                8.98 ns/op      111.30 MB/s
Benchmark32/2-4         200000000                9.46 ns/op      211.48 MB/s
Benchmark32/4-4         100000000               10.8 ns/op       370.43 MB/s
Benchmark32/8-4         100000000               12.6 ns/op       633.03 MB/s
```

but otherwise it's equivalent.