### PR TITLE
Murmur128: use Go 1.9 bits.RotateLeft64 functions

### DIFF
--- a/murmur128.go
+++ b/murmur128.go
@@ -4,6 +4,7 @@ import (
 	//"encoding/binary"
 	"hash"
 	"unsafe"
+	"math/bits"
 )
 
 const (
@@ -68,20 +69,20 @@ func (d *digest128) bmix(p []byte) (tail []byte) {
 		k1, k2 := t[0], t[1]
 
 		k1 *= c1_128
-		k1 = (k1 << 31) | (k1 >> 33) // rotl64(k1, 31)
+		k1 = bits.RotateLeft64(k1, 31)
 		k1 *= c2_128
 		h1 ^= k1
 
-		h1 = (h1 << 27) | (h1 >> 37) // rotl64(h1, 27)
+		h1 = bits.RotateLeft64(h1, 27)
 		h1 += h2
 		h1 = h1*5 + 0x52dce729
 
 		k2 *= c2_128
-		k2 = (k2 << 33) | (k2 >> 31) // rotl64(k2, 33)
+		k2 = bits.RotateLeft64(k2, 33)
 		k2 *= c1_128
 		h2 ^= k2
 
-		h2 = (h2 << 31) | (h2 >> 33) // rotl64(h2, 31)
+		h2 = bits.RotateLeft64(h2, 31)
 		h2 += h1
 		h2 = h2*5 + 0x38495ab5
 	}
@@ -117,7 +118,7 @@ func (d *digest128) Sum128() (h1, h2 uint64) {
 		k2 ^= uint64(d.tail[8]) << 0
 
 		k2 *= c2_128
-		k2 = (k2 << 33) | (k2 >> 31) // rotl64(k2, 33)
+		k2 = bits.RotateLeft64(k2, 33)
 		k2 *= c1_128
 		h2 ^= k2
 
@@ -147,7 +148,7 @@ func (d *digest128) Sum128() (h1, h2 uint64) {
 	case 1:
 		k1 ^= uint64(d.tail[0]) << 0
 		k1 *= c1_128
-		k1 = (k1 << 31) | (k1 >> 33) // rotl64(k1, 31)
+		k1 = bits.RotateLeft64(k1, 31)
 		k1 *= c2_128
 		h1 ^= k1
 	}


### PR DESCRIPTION
This PR introduces `bits.RotateLeft64` in place of 2 shifts + binary or operations

Sadly does not look like it improves performance (tested on a 2017 15' MacBookPro, Go 1.10.3)

without `bits.RotateLeft64`:
```
go test -run - -bench Benchmark128 .
goos: darwin
goarch: amd64
pkg: github.com/spaolacci/murmur3
Benchmark128/1-8 	100000000	        18.8 ns/op	  53.20 MB/s
Benchmark128/2-8 	100000000	        20.0 ns/op	 100.16 MB/s
Benchmark128/4-8 	100000000	        20.6 ns/op	 194.31 MB/s
Benchmark128/8-8 	100000000	        23.0 ns/op	 348.01 MB/s
Benchmark128/16-8         	100000000	        20.3 ns/op	 787.21 MB/s
Benchmark128/32-8         	100000000	        23.0 ns/op	1391.11 MB/s
Benchmark128/64-8         	50000000	        28.8 ns/op	2223.46 MB/s
Benchmark128/128-8        	50000000	        38.9 ns/op	3292.33 MB/s
Benchmark128/256-8        	20000000	        62.7 ns/op	4083.19 MB/s
Benchmark128/512-8        	20000000	       111 ns/op	4577.90 MB/s
Benchmark128/1024-8       	10000000	       209 ns/op	4877.98 MB/s
Benchmark128/2048-8       	 3000000	       419 ns/op	4885.73 MB/s
Benchmark128/4096-8       	 2000000	       804 ns/op	5093.00 MB/s
Benchmark128/8192-8       	 1000000	      1589 ns/op	5154.91 MB/s
```

with `bits.RotateLeft64`:
```
go test -run - -bench Benchmark128 .
goos: darwin
goarch: amd64
pkg: github.com/spaolacci/murmur3
Benchmark128/1-8 	100000000	        18.6 ns/op	  53.65 MB/s
Benchmark128/2-8 	100000000	        19.0 ns/op	 105.24 MB/s
Benchmark128/4-8 	100000000	        20.2 ns/op	 198.10 MB/s
Benchmark128/8-8 	100000000	        22.9 ns/op	 348.85 MB/s
Benchmark128/16-8         	100000000	        20.4 ns/op	 786.13 MB/s
Benchmark128/32-8         	100000000	        24.2 ns/op	1322.43 MB/s
Benchmark128/64-8         	50000000	        28.3 ns/op	2257.56 MB/s
Benchmark128/128-8        	30000000	        39.0 ns/op	3279.77 MB/s
Benchmark128/256-8        	20000000	        63.4 ns/op	4036.51 MB/s
Benchmark128/512-8        	 20000000	       113 ns/op	4520.35 MB/s
Benchmark128/1024-8       	  10000000	       222 ns/op	4604.64 MB/s
Benchmark128/2048-8       	 3000000	       432 ns/op	4739.47 MB/s
Benchmark128/4096-8       	 2000000	       781 ns/op	5240.30 MB/s
Benchmark128/8192-8       	 1000000	      1551 ns/op	5280.24 MB/s
```

I'm leaving it up for discussion. Perhaps someone else could run the benchmarks on different hardware.