### PR TITLE
Inline Sum128

### DIFF
--- a/murmur128.go
+++ b/murmur128.go
@@ -189,10 +189,104 @@ func Sum128(data []byte) (h1 uint64, h2 uint64) { return Sum128WithSeed(data, 0)
 //     hasher := New128WithSeed(seed)
 //     hasher.Write(data)
 //     return hasher.Sum128()
-func Sum128WithSeed(data []byte, seed uint32) (h1 uint64, h2 uint64) {
-	d := digest128{h1: uint64(seed), h2: uint64(seed)}
-	d.seed = seed
-	d.tail = d.bmix(data)
-	d.clen = len(data)
-	return d.Sum128()
+func Sum128WithSeed(p []byte, seed uint32) (h1 uint64, h2 uint64) {
+	h1, h2 = uint64(seed), uint64(seed)
+
+	nblocks := len(p) / 16
+	for i := 0; i < nblocks; i++ {
+		t := (*[2]uint64)(unsafe.Pointer(&p[i*16]))
+		k1, k2 := t[0], t[1]
+
+		k1 *= c1_128
+		k1 = bits.RotateLeft64(k1, 31)
+		k1 *= c2_128
+		h1 ^= k1
+
+		h1 = bits.RotateLeft64(h1, 27)
+		h1 += h2
+		h1 = h1*5 + 0x52dce729
+
+		k2 *= c2_128
+		k2 = bits.RotateLeft64(k2, 33)
+		k2 *= c1_128
+		h2 ^= k2
+
+		h2 = bits.RotateLeft64(h2, 31)
+		h2 += h1
+		h2 = h2*5 + 0x38495ab5
+	}
+
+	tail := p[nblocks*16:]
+	var k1, k2 uint64
+	switch len(tail) & 15 {
+	case 15:
+		k2 ^= uint64(tail[14]) << 48
+		fallthrough
+	case 14:
+		k2 ^= uint64(tail[13]) << 40
+		fallthrough
+	case 13:
+		k2 ^= uint64(tail[12]) << 32
+		fallthrough
+	case 12:
+		k2 ^= uint64(tail[11]) << 24
+		fallthrough
+	case 11:
+		k2 ^= uint64(tail[10]) << 16
+		fallthrough
+	case 10:
+		k2 ^= uint64(tail[9]) << 8
+		fallthrough
+	case 9:
+		k2 ^= uint64(tail[8]) << 0
+
+		k2 *= c2_128
+		k2 = bits.RotateLeft64(k2, 33)
+		k2 *= c1_128
+		h2 ^= k2
+
+		fallthrough
+
+	case 8:
+		k1 ^= uint64(tail[7]) << 56
+		fallthrough
+	case 7:
+		k1 ^= uint64(tail[6]) << 48
+		fallthrough
+	case 6:
+		k1 ^= uint64(tail[5]) << 40
+		fallthrough
+	case 5:
+		k1 ^= uint64(tail[4]) << 32
+		fallthrough
+	case 4:
+		k1 ^= uint64(tail[3]) << 24
+		fallthrough
+	case 3:
+		k1 ^= uint64(tail[2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint64(tail[1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint64(tail[0]) << 0
+		k1 *= c1_128
+		k1 = bits.RotateLeft64(k1, 31)
+		k1 *= c2_128
+		h1 ^= k1
+	}
+
+	h1 ^= uint64(len(p))
+	h2 ^= uint64(len(p))
+
+	h1 += h2
+	h2 += h1
+
+	h1 = fmix64(h1)
+	h2 = fmix64(h2)
+
+	h1 += h2
+	h2 += h1
+
+	return
 }

--- a/murmur64.go
+++ b/murmur64.go
@@ -48,10 +48,6 @@ func Sum64(data []byte) uint64 { return Sum64WithSeed(data, 0) }
 //     hasher.Write(data)
 //     return hasher.Sum64()
 func Sum64WithSeed(data []byte, seed uint32) uint64 {
-	d := digest128{h1: uint64(seed), h2: uint64(seed)}
-	d.seed = seed
-	d.tail = d.bmix(data)
-	d.clen = len(data)
-	h1, _ := d.Sum128()
+	h1, _ := Sum128WithSeed(data, seed)
 	return h1
 }


### PR DESCRIPTION
Inline implementation of Sum128WithSeed and use it for Sum64WithSeed.
It gives measurable difference on short strings.

Also, add a bit of randomness to benchmark to stress branch prediction in last block calculation.