### PR TITLE
Fix go 1.14's checkptr validation

### DIFF
--- a/murmur32.go
+++ b/murmur32.go
@@ -53,7 +53,7 @@ func (d *digest32) bmix(p []byte) (tail []byte) {
 
 	nblocks := len(p) / 4
 	for i := 0; i < nblocks; i++ {
-		k1 := *(*uint32)(unsafe.Pointer(&p[i*4]))
+		k1 := *(*uint32)(unsafe.Pointer(uintptr(unsafe.Pointer(&p[i*4]))))
 
 		k1 *= c1_32
 		k1 = bits.RotateLeft32(k1, 15)
@@ -121,7 +121,7 @@ func Sum32WithSeed(data []byte, seed uint32) uint32 {
 	}
 	p1 := p + uintptr(4*nblocks)
 	for ; p < p1; p += 4 {
-		k1 := *(*uint32)(unsafe.Pointer(p))
+		k1 := *(*uint32)(unsafe.Pointer(uintptr(unsafe.Pointer(p))))
 
 		k1 *= c1_32
 		k1 = bits.RotateLeft32(k1, 15)

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -187,3 +187,14 @@ func Benchmark128(b *testing.B) {
 		})
 	}
 }
+
+func TestUnalignedWrite(t *testing.T) {
+	// Causes "fatal error: checkptr: unsafe pointer conversion" for unsafe
+	// pointer conversions in Go 1.14+
+	b := make([]byte, 128)
+	for i := 0; i < 16; i++ {
+		Sum32(b[i:])
+		Sum64(b[i:])
+		Sum128(b[i:])
+	}
+}


### PR DESCRIPTION
Alternative fix to #30's checkptr validation for go 1.14.
Test is from @calmh's in #29.

The fix is based on go-cmp's discussion on a [similar issue](https://github.com/google/go-cmp/issues/167).

```
benchmark                     old ns/op     new ns/op     delta
Benchmark32/1-12              4.41          4.44          +0.68%
Benchmark32/2-12              4.79          4.81          +0.42%
Benchmark32/4-12              4.73          4.67          -1.27%
Benchmark32/8-12              5.62          5.57          -0.89%
Benchmark32/16-12             7.59          7.56          -0.40%
Benchmark32/32-12             11.5          11.6          +0.87%
Benchmark32/64-12             18.8          18.7          -0.53%
Benchmark32/128-12            35.5          35.3          -0.56%
Benchmark32/256-12            69.0          69.9          +1.30%
Benchmark32/512-12            139           139           +0.00%
Benchmark32/1024-12           272           273           +0.37%
Benchmark32/2048-12           538           542           +0.74%
Benchmark32/4096-12           1077          1083          +0.56%
Benchmark32/8192-12           2153          2197          +2.04%
BenchmarkPartial32/8-12       146           149           +2.05%
BenchmarkPartial32/16-12      173           174           +0.58%
BenchmarkPartial32/32-12      231           226           -2.16%
BenchmarkPartial32/64-12      191           192           +0.52%
BenchmarkPartial32/128-12     209           209           +0.00%
Benchmark64/1-12              12.1          12.1          +0.00%
Benchmark64/2-12              12.3          12.6          +2.44%
Benchmark64/4-12              13.5          13.7          +1.48%
Benchmark64/8-12              15.3          15.4          +0.65%
Benchmark64/16-12             13.4          13.3          -0.75%
Benchmark64/32-12             15.4          15.4          +0.00%
Benchmark64/64-12             19.8          19.6          -1.01%
Benchmark64/128-12            27.9          28.2          +1.08%
Benchmark64/256-12            49.3          45.0          -8.72%
Benchmark64/512-12            81.4          78.6          -3.44%
Benchmark64/1024-12           150           145           -3.33%
Benchmark64/2048-12           289           282           -2.42%
Benchmark64/4096-12           561           559           -0.36%
Benchmark64/8192-12           1093          1098          +0.46%
Benchmark128/1-12             17.1          15.4          -9.94%
Benchmark128/2-12             15.2          15.0          -1.32%
Benchmark128/4-12             16.4          14.9          -9.15%
Benchmark128/8-12             17.1          17.2          +0.58%
Benchmark128/16-12            15.7          15.3          -2.55%
Benchmark128/32-12            16.5          18.9          +14.55%
Benchmark128/64-12            22.5          22.7          +0.89%
Benchmark128/128-12           30.8          31.0          +0.65%
Benchmark128/256-12           47.5          48.7          +2.53%
Benchmark128/512-12           80.4          81.3          +1.12%
Benchmark128/1024-12          148           147           -0.68%
Benchmark128/2048-12          285           288           +1.05%
Benchmark128/4096-12          559           553           -1.07%
Benchmark128/8192-12          1071          1095          +2.24%
```