### PR TITLE
implement io.StringWriter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/segmentio/murmur3
+
+go 1.17

--- a/murmur.go
+++ b/murmur.go
@@ -14,66 +14,34 @@ Package murmur3 implements Austin Appleby's non-cryptographic MurmurHash3.
 */
 package murmur3
 
-import (
-	"unsafe"
-)
-
-type bmixer interface {
-	bmix(p []byte) (tail []byte)
-	Size() (n int)
-	reset()
-}
-
 type digest struct {
 	clen int      // Digested input cumulative length.
 	tail []byte   // 0 to Size()-1 bytes view of `buf'.
 	buf  [16]byte // Expected (but not required) to be Size() large.
 	seed uint32   // Seed for initializing the hash.
-	bmixer
-}
-
-// sliceHeader is similar to reflect.SliceHeader, but it assumes that the layout
-// of the first two words is the same as the layout of a string.
-type sliceHeader struct {
-	s   string
-	cap int
 }
 
 func (d *digest) BlockSize() int { return 1 }
 
-func (d *digest) WriteString(s string) (int, error) {
-	// This code does the same as:
-	//
-	//   return d.Write([]byte(s))
-	//
-	// because the parameter `p` to Write is passed to d.bmix, which is an
-	// interface type, the simple conversion to a byte slice forces the compiler
-	// to make a heap allocation and copy the slice. The use of unsafe here lets
-	// us take over the default behavior of the compiler to have the byte slice
-	// share the underlying memory buffer of the string and avoid the extra heap
-	// allocation.
-	return d.Write(*(*[]byte)(unsafe.Pointer(&sliceHeader{s: s, cap: len(s)})))
-}
-
-func (d *digest) Write(p []byte) (n int, err error) {
+func (d *digest) write(p []byte, size int, bmix func([]byte) []byte) (n int, err error) {
 	n = len(p)
 	d.clen += n
 
 	if len(d.tail) > 0 {
 		// Stick back pending bytes.
-		nfree := d.Size() - len(d.tail) // nfree ∈ [1, d.Size()-1].
+		nfree := size - len(d.tail) // nfree ∈ [1, d.Size()-1].
 		if nfree < len(p) {
 			// One full block can be formed.
 			block := append(d.tail, p[:nfree]...)
 			p = p[nfree:]
-			_ = d.bmix(block) // No tail.
+			_ = bmix(block) // No tail.
 		} else {
 			// Tail's buf is large enough to prevent reallocs.
 			p = append(d.tail, p...)
 		}
 	}
 
-	d.tail = d.bmix(p)
+	d.tail = bmix(p)
 
 	// Keep own copy of the 0 to Size()-1 pending bytes.
 	nn := copy(d.buf[:], d.tail)
@@ -82,8 +50,7 @@ func (d *digest) Write(p []byte) (n int, err error) {
 	return n, nil
 }
 
-func (d *digest) Reset() {
+func (d *digest) reset() {
 	d.clen = 0
 	d.tail = nil
-	d.bmixer.reset()
 }

--- a/murmur128.go
+++ b/murmur128.go
@@ -14,9 +14,9 @@ const (
 
 // Make sure interfaces are correctly implemented.
 var (
-	_ hash.Hash = new(digest128)
-	_ Hash128   = new(digest128)
-	_ bmixer    = new(digest128)
+	_ hash.Hash = new(Digest128)
+	_ Hash128   = new(Digest128)
+	_ bmixer    = new(Digest128)
 )
 
 // Hash128 represents a 128-bit hasher
@@ -26,30 +26,30 @@ type Hash128 interface {
 	Sum128() (uint64, uint64)
 }
 
-// digest128 represents a partial evaluation of a 128 bites hash.
-type digest128 struct {
+// Digest128 represents a partial evaluation of a 128 bites hash.
+type Digest128 struct {
 	digest
 	h1 uint64 // Unfinalized running hash part 1.
 	h2 uint64 // Unfinalized running hash part 2.
 }
 
 // New128 returns a 128-bit hasher
-func New128() Hash128 { return New128WithSeed(0) }
+func New128() *Digest128 { return New128WithSeed(0) }
 
 // New128WithSeed returns a 128-bit hasher set with explicit seed value
-func New128WithSeed(seed uint32) Hash128 {
-	d := new(digest128)
+func New128WithSeed(seed uint32) *Digest128 {
+	d := new(Digest128)
 	d.seed = seed
 	d.bmixer = d
 	d.Reset()
 	return d
 }
 
-func (d *digest128) Size() int { return 16 }
+func (d *Digest128) Size() int { return 16 }
 
-func (d *digest128) reset() { d.h1, d.h2 = uint64(d.seed), uint64(d.seed) }
+func (d *Digest128) reset() { d.h1, d.h2 = uint64(d.seed), uint64(d.seed) }
 
-func (d *digest128) Sum(b []byte) []byte {
+func (d *Digest128) Sum(b []byte) []byte {
 	h1, h2 := d.Sum128()
 	return append(b,
 		byte(h1>>56), byte(h1>>48), byte(h1>>40), byte(h1>>32),
@@ -60,7 +60,7 @@ func (d *digest128) Sum(b []byte) []byte {
 	)
 }
 
-func (d *digest128) bmix(p []byte) (tail []byte) {
+func (d *Digest128) bmix(p []byte) (tail []byte) {
 	h1, h2 := d.h1, d.h2
 
 	nblocks := len(p) / 16
@@ -90,7 +90,7 @@ func (d *digest128) bmix(p []byte) (tail []byte) {
 	return p[nblocks*d.Size():]
 }
 
-func (d *digest128) Sum128() (h1, h2 uint64) {
+func (d *Digest128) Sum128() (h1, h2 uint64) {
 
 	h1, h2 = d.h1, d.h2
 
@@ -190,7 +190,7 @@ func Sum128(data []byte) (h1 uint64, h2 uint64) { return Sum128WithSeed(data, 0)
 //     hasher.Write(data)
 //     return hasher.Sum128()
 func Sum128WithSeed(data []byte, seed uint32) (h1 uint64, h2 uint64) {
-	d := digest128{h1: uint64(seed), h2: uint64(seed)}
+	d := Digest128{h1: uint64(seed), h2: uint64(seed)}
 	d.seed = seed
 	d.tail = d.bmix(data)
 	d.clen = len(data)

--- a/murmur32.go
+++ b/murmur32.go
@@ -10,9 +10,9 @@ import (
 
 // Make sure interfaces are correctly implemented.
 var (
-	_ hash.Hash   = new(digest32)
-	_ hash.Hash32 = new(digest32)
-	_ bmixer      = new(digest32)
+	_ hash.Hash   = new(Digest32)
+	_ hash.Hash32 = new(Digest32)
+	_ bmixer      = new(Digest32)
 )
 
 const (
@@ -20,35 +20,35 @@ const (
 	c2_32 uint32 = 0x1b873593
 )
 
-// digest32 represents a partial evaluation of a 32 bites hash.
-type digest32 struct {
+// Digest32 represents a partial evaluation of a 32 bites hash.
+type Digest32 struct {
 	digest
 	h1 uint32 // Unfinalized running hash.
 }
 
 // New32 returns new 32-bit hasher
-func New32() hash.Hash32 { return New32WithSeed(0) }
+func New32() *Digest32 { return New32WithSeed(0) }
 
 // New32WithSeed returns new 32-bit hasher set with explicit seed value
-func New32WithSeed(seed uint32) hash.Hash32 {
-	d := new(digest32)
+func New32WithSeed(seed uint32) *Digest32 {
+	d := new(Digest32)
 	d.seed = seed
 	d.bmixer = d
 	d.Reset()
 	return d
 }
 
-func (d *digest32) Size() int { return 4 }
+func (d *Digest32) Size() int { return 4 }
 
-func (d *digest32) reset() { d.h1 = d.seed }
+func (d *Digest32) reset() { d.h1 = d.seed }
 
-func (d *digest32) Sum(b []byte) []byte {
+func (d *Digest32) Sum(b []byte) []byte {
 	h := d.Sum32()
 	return append(b, byte(h>>24), byte(h>>16), byte(h>>8), byte(h))
 }
 
-// Digest as many blocks as possible.
-func (d *digest32) bmix(p []byte) (tail []byte) {
+// digest as many blocks as possible.
+func (d *Digest32) bmix(p []byte) (tail []byte) {
 	h1 := d.h1
 
 	nblocks := len(p) / 4
@@ -67,7 +67,7 @@ func (d *digest32) bmix(p []byte) (tail []byte) {
 	return p[nblocks*d.Size():]
 }
 
-func (d *digest32) Sum32() (h1 uint32) {
+func (d *Digest32) Sum32() (h1 uint32) {
 
 	h1 = d.h1
 

--- a/murmur64.go
+++ b/murmur64.go
@@ -6,32 +6,32 @@ import (
 
 // Make sure interfaces are correctly implemented.
 var (
-	_ hash.Hash   = new(digest64)
-	_ hash.Hash64 = new(digest64)
-	_ bmixer      = new(digest64)
+	_ hash.Hash   = new(Digest64)
+	_ hash.Hash64 = new(Digest64)
+	_ bmixer      = new(Digest64)
 )
 
-// digest64 is half a digest128.
-type digest64 digest128
+// Digest64 is half a Digest128.
+type Digest64 Digest128
 
 // New64 returns a 64-bit hasher
-func New64() hash.Hash64 { return New64WithSeed(0) }
+func New64() *Digest64 { return New64WithSeed(0) }
 
 // New64WithSeed returns a 64-bit hasher set with explicit seed value
-func New64WithSeed(seed uint32) hash.Hash64 {
-	d := (*digest64)(New128WithSeed(seed).(*digest128))
+func New64WithSeed(seed uint32) *Digest64 {
+	d := (*Digest64)(New128WithSeed(seed))
 	return d
 }
 
-func (d *digest64) Sum(b []byte) []byte {
+func (d *Digest64) Sum(b []byte) []byte {
 	h1 := d.Sum64()
 	return append(b,
 		byte(h1>>56), byte(h1>>48), byte(h1>>40), byte(h1>>32),
 		byte(h1>>24), byte(h1>>16), byte(h1>>8), byte(h1))
 }
 
-func (d *digest64) Sum64() uint64 {
-	h1, _ := (*digest128)(d).Sum128()
+func (d *Digest64) Sum64() uint64 {
+	h1, _ := (*Digest128)(d).Sum128()
 	return h1
 }
 
@@ -48,7 +48,7 @@ func Sum64(data []byte) uint64 { return Sum64WithSeed(data, 0) }
 //     hasher.Write(data)
 //     return hasher.Sum64()
 func Sum64WithSeed(data []byte, seed uint32) uint64 {
-	d := digest128{h1: uint64(seed), h2: uint64(seed)}
+	d := Digest128{h1: uint64(seed), h2: uint64(seed)}
 	d.seed = seed
 	d.tail = d.bmix(data)
 	d.clen = len(data)

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -2,6 +2,7 @@ package murmur3
 
 import (
 	"fmt"
+	"io"
 	"strconv"
 	"testing"
 )
@@ -183,6 +184,22 @@ func Benchmark128(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				Sum128(buf)
+			}
+		})
+	}
+}
+
+func BenchmarkWriteString(b *testing.B) {
+	buf := make([]byte, 8192)
+	for length := 1; length <= cap(buf); length *= 2 {
+		b.Run(strconv.Itoa(length), func(b *testing.B) {
+			s := string(buf[:length])
+			h := New32()
+			b.SetBytes(int64(length))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				io.WriteString(h, s)
 			}
 		})
 	}

--- a/unsafe.go
+++ b/unsafe.go
@@ -1,0 +1,12 @@
+package murmur3
+
+import "unsafe"
+
+func unsafeStringToBytes(s string) []byte {
+	return *(*[]byte)(unsafe.Pointer(&sliceHeader{str: s, cap: len(s)}))
+}
+
+type sliceHeader struct {
+	str string
+	cap int
+}


### PR DESCRIPTION
Hello!

This PR adds a `WriteString` method to the internal `digest` type to implement the `io.StringWriter` interface and avoid memory copies when hashing strings.

I added a benchmark and ran it before and after the change to demonstrate that a heap allocation is removed by providing this method:
```
benchmark                   old ns/op     new ns/op     delta
BenchmarkWriteString/1      46.0          30.8          -33.04%
BenchmarkWriteString/2      46.1          31.8          -31.02%
BenchmarkWriteString/4      43.5          28.4          -34.71%
BenchmarkWriteString/8      42.1          28.9          -31.35%
BenchmarkWriteString/16     48.3          31.3          -35.20%
BenchmarkWriteString/32     54.2          34.9          -35.61%

benchmark                   old MB/s     new MB/s     speedup
BenchmarkWriteString/1      21.75        32.46        1.49x
BenchmarkWriteString/2      43.43        62.89        1.45x
BenchmarkWriteString/4      92.01        140.65       1.53x
BenchmarkWriteString/8      190.10       277.23       1.46x
BenchmarkWriteString/16     331.10       510.92       1.54x
BenchmarkWriteString/32     590.65       916.96       1.55x

benchmark                   old allocs     new allocs     delta
BenchmarkWriteString/1      1              0              -100.00%
BenchmarkWriteString/2      1              0              -100.00%
BenchmarkWriteString/4      1              0              -100.00%
BenchmarkWriteString/8      1              0              -100.00%
BenchmarkWriteString/16     1              0              -100.00%
BenchmarkWriteString/32     1              0              -100.00%

benchmark                   old bytes     new bytes     delta
BenchmarkWriteString/1      8             0             -100.00%
BenchmarkWriteString/2      8             0             -100.00%
BenchmarkWriteString/4      8             0             -100.00%
BenchmarkWriteString/8      8             0             -100.00%
BenchmarkWriteString/16     16            0             -100.00%
BenchmarkWriteString/32     32            0             -100.00%
```

The use of the `unsafe` package is a bit unfortunate, but it seemed like the package already depended on it, so this change doesn't introduce a new dependency on `unsafe`.

Let me know if you'd like to see anything changed!